### PR TITLE
Fix: Jest sequential execution for Windows compatibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,4 +16,5 @@ export default {
     },
   },
   testTimeout: 10000,
+  maxWorkers: 1,
 };


### PR DESCRIPTION
Configure Jest to run tests sequentially (maxWorkers: 1) to prevent Windows file system race conditions during concurrent test execution.