### PR TITLE
Add auto-assign issues workflow

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,29 @@
+name: Auto-Assign Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Auto-assign issue to repository owner
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Get the repository owner
+            const owner = context.repo.owner;
+
+            // Assign the issue to the owner
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [owner]
+            });
+
+            console.log(`✓ Assigned issue #${context.issue.number} to @${owner}`);


### PR DESCRIPTION
Automatically assigns new issues to repository owner (you) when they are opened.

## What This Does

- Listens for new issues
- Automatically assigns them to @mschultheiss83 (repo owner)
- Minimal permissions (issues write only)
- Zero configuration needed

## Benefits

- No more forgetting to assign issues
- Keeps workflow organized
- Quick turnaround on new issues

🤖 Generated with Claude Code